### PR TITLE
Only use package_folder_prefix if there any subpackages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,4 +32,10 @@ gawk -F '\n' '{ match($1, /(drivers|helpers)\/(.+)\/(.+)\:/, arr) ; if (length(a
 gawk '{ trimmed = substr($0, 1, length($0) - 2) ; print "\"" trimmed "\"" }'
 )
 
-circuitpython-build-bundles --filename_prefix circuitpython-org-bundle --library_location libraries --library_depth 2 --package_folder_prefix "$P"
+if [ -z "$P" ]; then
+  P=""
+else
+  P="--package_folder_prefix $P"
+fi
+
+circuitpython-build-bundles --filename_prefix circuitpython-org-bundle --library_location libraries --library_depth 2 "$P"


### PR DESCRIPTION
`circuitpython-build-bundles` fails if called with no parameter for `--package_folder_prefix`
This only includes the option once there is a submodule with a directory in it.

Fixes problem discovered on @FoamyGuy stream today.