### PR TITLE
adding dial widget

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libraries/helpers/displayio_annotation"]
 	path = libraries/helpers/displayio_annotation
 	url = https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Annotation.git
+[submodule "libraries/helpers/displayio_dial"]
+	path = libraries/helpers/displayio_dial
+	url = https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Dial.git


### PR DESCRIPTION
The Dial widget is now all set up in it's new repo and has been updated to use the newest vectorio API.

This adds it to the bundle.