### PR TITLE
Add displayio_effects library to bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "libraries/helpers/displayio_dial"]
 	path = libraries/helpers/displayio_dial
 	url = https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Dial.git
+[submodule "libraries/helpers/displayio_effects"]
+	path = libraries/helpers/displayio_effects
+	url = https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Effects.git


### PR DESCRIPTION
Adds the new `displayio_effects` library to the bundle!  Points to the CircuitPython Org fork.

Also happy to make changes to the actual library as part of the PR.  I made an initial release for the library but can submit a PR with changes to it as needed.